### PR TITLE
Implement support for generic log formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tailstream Agent
 
-A lightweight Go agent that automatically discovers and parses common web server access logs, converting them to structured JSON format and shipping them to the Tailstream ingest API for real-time log analysis.
+A lightweight Go agent that automatically discovers and ships logs to the Tailstream ingest API for real-time log analysis. Supports web server access logs, JSON logs, custom formats, and raw text logs.
 
 ## ⚡ Quick Start
 
@@ -294,6 +294,8 @@ streams:
 - **Organized log routing**: Route nginx logs, application logs, and system logs separately
 - **Flexible patterns**: Each stream can have its own include/exclude patterns
 - **Custom log formats**: Define custom regex patterns to parse application-specific logs
+- **Auto-format detection**: Each stream automatically detects formats (JSON, access logs, plain text)
+- **Mixed formats per stream**: A single stream can handle multiple file formats simultaneously
 - **Backward compatible**: Existing single-stream configs continue to work
 
 ### Custom Log Formats
@@ -472,42 +474,24 @@ Note: With environment variables only, you'll need to run the setup wizard on fi
 
 1. **Discovery**: The agent scans filesystem paths using glob patterns to find log files
 2. **Tailing**: Continuously monitors discovered files for new lines (similar to `tail -f`)
-3. **Parsing**: Intelligently parses common access log formats into structured JSON
-4. **Normalization**: Converts all logs to Tailstream's required NDJSON format
-5. **Batching**: Collects up to 100 events or waits 2 seconds before shipping
-6. **Shipping**: Sends batches via HTTP POST to Tailstream ingest API as NDJSON
+3. **Parsing**: Automatically detects and parses log formats
+4. **Batching**: Collects up to 100 events or waits 2 seconds before shipping
+5. **Shipping**: Sends batches via HTTP POST to Tailstream ingest API as NDJSON
 
 ### Supported Log Formats
 
-The agent automatically detects and parses:
+The agent automatically detects and handles multiple log formats:
 
-#### **Access Logs** (converted to structured JSON)
-- **Nginx Combined Format**: `IP - - [timestamp] "METHOD path HTTP/version" status bytes "referer" "user-agent"`
-- **Nginx with Response Time**: Same as above + response time at the end
-- **Apache Common Format**: `IP - - [timestamp] "METHOD path HTTP/version" status bytes`
-- **Apache Combined Format**: Common format + referer and user-agent
+#### **Auto-Detected Formats**
+- **Nginx/Apache Access Logs** - Automatically parsed to structured JSON
+- **JSON Logs** - Validated and forwarded as JSON
+- **Plain Text Logs** - Sent as-is (syslogs, application logs, etc.)
+  - Backend auto-detects format for Laravel logs, syslogs, and other text formats
 
-#### **JSON Logs**
-- Pre-structured JSON logs are validated and forwarded with required fields
-
-#### **Output Format**
-All logs are converted to this structured format required by Tailstream:
-```json
-{
-  "host": "server-hostname",
-  "path": "/api/endpoint",
-  "method": "GET",
-  "status": 200,
-  "rt": 0.123,
-  "bytes": 1024,
-  "src": "/var/log/nginx/access.log",
-  "ip": "192.168.1.1",
-  "user_agent": "Mozilla/5.0..."
-}
-```
-
-**Required Fields:** `host`, `path`, `method`, `status`, `rt`, `bytes`, `src`
-**Optional Fields:** `ip`, `user_agent`, `ts`
+#### **Custom Formats**
+- Define custom regex patterns per stream
+- Map log fields to structured output
+- See "Custom Log Formats" section for examples
 
 ## Testing
 

--- a/agent/custom_format_test.go
+++ b/agent/custom_format_test.go
@@ -100,9 +100,15 @@ func TestCustomAccessLogFormats(t *testing.T) {
 				t.Fatalf("Expected parseCustomFormat to succeed for %s", tt.name)
 			}
 
+			// Event should be a map for custom formats
+			eventMap, ok := event.(map[string]interface{})
+			if !ok {
+				t.Fatalf("Expected event to be a map, got type: %T", event)
+			}
+
 			// Check all expected fields
 			for key, expectedValue := range tt.expected {
-				actualValue, exists := event[key]
+				actualValue, exists := eventMap[key]
 				if !exists {
 					t.Errorf("Expected field %s to exist in event", key)
 					continue
@@ -114,8 +120,8 @@ func TestCustomAccessLogFormats(t *testing.T) {
 			}
 
 			// Ensure host is set
-			if event["host"] != "test-host" {
-				t.Errorf("Expected host to be 'test-host', got %v", event["host"])
+			if eventMap["host"] != "test-host" {
+				t.Errorf("Expected host to be 'test-host', got %v", eventMap["host"])
 			}
 		})
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -147,21 +147,15 @@ func shipEvents(ctx context.Context, stream StreamConfig, globalKey string, even
 	// Convert events to NDJSON format
 	var buf bytes.Buffer
 	for _, event := range events {
-		// Check if event is a raw string or structured JSON
-		switch v := event.(type) {
-		case string:
-			// Raw text log - send as-is
-			buf.WriteString(v)
-			buf.WriteByte('\n')
-		default:
-			// Structured JSON - marshal and send
-			data, err := json.Marshal(event)
-			if err != nil {
-				continue
-			}
-			buf.Write(data)
-			buf.WriteByte('\n')
+		// Marshal event to JSON (handles both strings and objects)
+		// - Strings become JSON strings: "raw text here\n"
+		// - Objects become JSON objects: {"field":"value"}
+		data, err := json.Marshal(event)
+		if err != nil {
+			continue
 		}
+		buf.Write(data)
+		buf.WriteByte('\n')
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &buf)

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -42,7 +42,11 @@ func TestParseLineJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("not parsed")
 	}
-	if ev["msg"] != "hi" || ev["host"] != "host1" || ev["src"] != "/var/log/test.log" {
-		t.Fatalf("bad event: %#v", ev)
+	evMap, ok := ev.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected event to be a map, got type: %T", ev)
+	}
+	if evMap["msg"] != "hi" || evMap["host"] != "host1" || evMap["src"] != "/var/log/test.log" {
+		t.Fatalf("bad event: %#v", evMap)
 	}
 }

--- a/agent/multi_stream_test.go
+++ b/agent/multi_stream_test.go
@@ -100,3 +100,159 @@ func TestStreamConfigValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestSingleStreamMultipleFormats(t *testing.T) {
+	// Test that a SINGLE stream can handle multiple log formats from different files
+	stream := StreamConfig{
+		Name:     "mixed-stream",
+		StreamID: "stream-1",
+		Format:   nil, // No custom format - rely on auto-detection
+	}
+
+	tests := []struct {
+		name         string
+		logLine      string
+		expectedType string // "map" or "string"
+	}{
+		{
+			name:         "nginx access log",
+			logLine:      `192.168.1.1 - - [22/Sep/2025:17:04:36 +0000] "GET /api/test HTTP/1.1" 200 1024 "-" "curl/7.68.0"`,
+			expectedType: "map",
+		},
+		{
+			name:         "JSON log",
+			logLine:      `{"host":"server1","path":"/api","method":"GET","status":200,"rt":0.1,"bytes":500}`,
+			expectedType: "map",
+		},
+		{
+			name:         "plain text syslog",
+			logLine:      "2024-01-15T10:30:45Z ERROR Database connection failed",
+			expectedType: "string",
+		},
+		{
+			name:         "plain text error log",
+			logLine:      "[ERROR] Connection timeout at 10:30:45",
+			expectedType: "string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ll := LogLine{File: "/test.log", Line: tt.logLine}
+			event, ok := parseLine(ll, "testhost", stream.Format)
+
+			if !ok {
+				t.Fatalf("parseLine() failed for %s", tt.name)
+			}
+
+			// Check event type matches expectation
+			switch tt.expectedType {
+			case "string":
+				if _, isString := event.(string); !isString {
+					t.Errorf("Expected event to be string, got type: %T", event)
+				}
+			case "map":
+				if _, isMap := event.(map[string]interface{}); !isMap {
+					t.Errorf("Expected event to be map, got type: %T", event)
+				}
+			}
+		})
+	}
+}
+
+func TestMultiStreamDifferentFormats(t *testing.T) {
+	// Test that different streams can use different log formats
+	tests := []struct {
+		name           string
+		stream         StreamConfig
+		logLine        string
+		expectedType   string // "map" or "string"
+		shouldParse    bool
+	}{
+		{
+			name: "stream 1: nginx access log (auto-parsed to JSON)",
+			stream: StreamConfig{
+				Name:     "nginx-stream",
+				StreamID: "stream-1",
+				Format:   nil, // No custom format, will auto-detect
+			},
+			logLine:      `192.168.1.1 - - [22/Sep/2025:17:04:36 +0000] "GET /api/test HTTP/1.1" 200 1024 "-" "curl/7.68.0"`,
+			expectedType: "map",
+			shouldParse:  true,
+		},
+		{
+			name: "stream 2: custom app format (custom parsed to JSON)",
+			stream: StreamConfig{
+				Name:     "app-stream",
+				StreamID: "stream-2",
+				Format: &LogFormat{
+					Name:    "myapp",
+					Pattern: `\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\] (\w+)\.(\w+): (.+)`,
+					Fields: map[string]string{
+						"method": "2",
+						"path":   "3",
+						"host":   "hostname",
+					},
+					Default: map[string]any{
+						"status": 200,
+						"rt":     0.0,
+						"bytes":  0,
+					},
+				},
+			},
+			logLine:      "[2024-01-15 10:30:45] production.ERROR: Connection timeout",
+			expectedType: "map",
+			shouldParse:  true,
+		},
+		{
+			name: "stream 3: raw syslog (sent as raw string)",
+			stream: StreamConfig{
+				Name:     "syslog-stream",
+				StreamID: "stream-3",
+				Format:   nil, // No custom format
+			},
+			logLine:      "2024-01-15T10:30:45Z ERROR Database connection failed",
+			expectedType: "string",
+			shouldParse:  true,
+		},
+		{
+			name: "stream 4: JSON logs (parsed to JSON)",
+			stream: StreamConfig{
+				Name:     "json-stream",
+				StreamID: "stream-4",
+				Format:   nil,
+			},
+			logLine:      `{"host":"server1","path":"/api","method":"GET","status":200,"rt":0.1,"bytes":500}`,
+			expectedType: "map",
+			shouldParse:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ll := LogLine{File: "/test.log", Line: tt.logLine}
+			event, ok := parseLine(ll, "testhost", tt.stream.Format)
+
+			if ok != tt.shouldParse {
+				t.Errorf("parseLine() ok = %v, want %v", ok, tt.shouldParse)
+				return
+			}
+
+			if !ok {
+				return
+			}
+
+			// Check event type matches expectation
+			switch tt.expectedType {
+			case "string":
+				if _, isString := event.(string); !isString {
+					t.Errorf("Expected event to be string for stream %s, got type: %T", tt.stream.Name, event)
+				}
+			case "map":
+				if _, isMap := event.(map[string]interface{}); !isMap {
+					t.Errorf("Expected event to be map for stream %s, got type: %T", tt.stream.Name, event)
+				}
+			}
+		})
+	}
+}

--- a/agent/ndjson_format_test.go
+++ b/agent/ndjson_format_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNDJSONFormatCorrectness(t *testing.T) {
+	// Verify that NDJSON output matches backend expectations:
+	// Each line must be valid JSON (either object or string)
+
+	events := []Event{
+		// Structured JSON event
+		map[string]interface{}{
+			"host":   "server1",
+			"path":   "/api",
+			"method": "GET",
+			"status": 200,
+			"rt":     0.1,
+			"bytes":  500,
+			"src":    "access.log",
+		},
+		// Raw text events (should become JSON strings)
+		"2024-01-15T10:30:45Z ERROR Database connection failed",
+		"[2024-01-15 10:30:46] production.ERROR: Connection timeout",
+	}
+
+	// Simulate the shipEvents NDJSON conversion
+	var buf bytes.Buffer
+	for _, event := range events {
+		data, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("Failed to marshal event: %v", err)
+		}
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	if len(lines) != 3 {
+		t.Fatalf("Expected 3 lines in NDJSON output, got %d", len(lines))
+	}
+
+	// Verify each line is valid JSON
+	for i, line := range lines {
+		var v interface{}
+		if err := json.Unmarshal([]byte(line), &v); err != nil {
+			t.Errorf("Line %d is not valid JSON: %s\nError: %v", i+1, line, err)
+		}
+	}
+
+	// Verify line 1 is a JSON object
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(lines[0]), &obj); err != nil {
+		t.Errorf("Line 1 should be a JSON object: %v", err)
+	} else {
+		if obj["host"] != "server1" {
+			t.Errorf("Expected host=server1, got %v", obj["host"])
+		}
+	}
+
+	// Verify lines 2 and 3 are JSON strings
+	var str1, str2 string
+	if err := json.Unmarshal([]byte(lines[1]), &str1); err != nil {
+		t.Errorf("Line 2 should be a JSON string: %v", err)
+	} else {
+		if str1 != "2024-01-15T10:30:45Z ERROR Database connection failed" {
+			t.Errorf("Line 2 string content mismatch: %s", str1)
+		}
+	}
+
+	if err := json.Unmarshal([]byte(lines[2]), &str2); err != nil {
+		t.Errorf("Line 3 should be a JSON string: %v", err)
+	} else {
+		if str2 != "[2024-01-15 10:30:46] production.ERROR: Connection timeout" {
+			t.Errorf("Line 3 string content mismatch: %s", str2)
+		}
+	}
+}
+
+func TestNDJSONContentType(t *testing.T) {
+	// Verify Content-Type header is correct
+	// This is already tested in shipping_test.go but we document it here
+	expectedContentType := "application/x-ndjson"
+
+	// In the real code, shipEvents sets:
+	// req.Header.Set("Content-Type", "application/x-ndjson")
+
+	if expectedContentType != "application/x-ndjson" {
+		t.Errorf("Content-Type should be application/x-ndjson")
+	}
+}

--- a/agent/parser.go
+++ b/agent/parser.go
@@ -9,7 +9,8 @@ import (
 )
 
 // Event is the normalized record to send to Tailstream.
-type Event map[string]interface{}
+// It can be either a structured JSON object (map) or a raw text string.
+type Event interface{}
 
 // AccessLogEntry represents a parsed access log entry
 type AccessLogEntry struct {
@@ -111,7 +112,7 @@ func parseCustomFormat(line, filename, hostname string, format *LogFormat) (Even
 		return nil, false
 	}
 
-	event := make(Event)
+	event := make(map[string]interface{})
 
 	// Apply default values first
 	for key, value := range format.Default {
@@ -192,9 +193,7 @@ func parseLine(ll LogLine, host string, customFormat *LogFormat) (Event, bool) {
 		return event, true
 	}
 
-	// Skip unparseable lines
-	if os.Getenv("DEBUG") == "1" {
-		log.Printf("Skipping unparseable line from %s: %s", ll.File, ll.Line)
-	}
-	return nil, false
+	// Fallback: send as raw text log (backend will parse it)
+	// Backend auto-detects format for plain text, syslog, Laravel logs, etc.
+	return ll.Line, true
 }

--- a/agent/shipping_test.go
+++ b/agent/shipping_test.go
@@ -29,7 +29,7 @@ func TestShipEvents(t *testing.T) {
 			},
 			globalKey: "global-key",
 			events: []Event{
-				{"host": "test", "path": "/test", "method": "GET", "status": 200, "rt": 0.1, "bytes": 100, "src": "test.log"},
+				map[string]interface{}{"host": "test", "path": "/test", "method": "GET", "status": 200, "rt": 0.1, "bytes": 100, "src": "test.log"},
 			},
 			serverResponse: 200,
 			serverBody:     `{"accepted": 1}`,
@@ -45,7 +45,7 @@ func TestShipEvents(t *testing.T) {
 			},
 			globalKey: "global-key",
 			events: []Event{
-				{"host": "test", "path": "/test", "method": "GET", "status": 200, "rt": 0.1, "bytes": 100, "src": "test.log"},
+				map[string]interface{}{"host": "test", "path": "/test", "method": "GET", "status": 200, "rt": 0.1, "bytes": 100, "src": "test.log"},
 			},
 			serverResponse: 200,
 			serverBody:     `{"accepted": 1}`,
@@ -60,7 +60,7 @@ func TestShipEvents(t *testing.T) {
 				Key:      "test-key",
 			},
 			events: []Event{
-				{"host": "test", "path": "/test", "method": "GET", "status": 200, "rt": 0.1, "bytes": 100, "src": "test.log"},
+				map[string]interface{}{"host": "test", "path": "/test", "method": "GET", "status": 200, "rt": 0.1, "bytes": 100, "src": "test.log"},
 			},
 			serverResponse: 401,
 			serverBody:     `{"error": "unauthorized"}`,


### PR DESCRIPTION
- Update README to clarify log format support, emphasizing automatic detection and handling of various log types including access logs, JSON logs, and plain text logs.
- Refactor log parsing to support raw text logs, allowing the backend to auto-detect formats for syslogs and application logs.
- Improve test coverage for multi-stream configurations, ensuring different log formats are correctly parsed and handled.
- Adjust event handling to differentiate between structured JSON and raw text logs during shipping.