### PR TITLE
Enhance update checking mechanism and add macOS binary support

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -447,9 +447,21 @@ func main() {
 		return
 	}
 
-	// Check for updates in the background
-	go checkForUpdates(cfg)
 	host, _ := os.Hostname()
+
+	// Start background update checker
+	go func() {
+		// Run initial check
+		checkForUpdates(cfg)
+
+		// Set up ticker for periodic checks
+		updateTicker := time.NewTicker(5 * time.Minute)
+		defer updateTicker.Stop()
+
+		for range updateTicker.C {
+			checkForUpdates(cfg)
+		}
+	}()
 
 	// Validate required configuration
 	if len(cfg.Streams) == 0 {

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -174,7 +174,17 @@ func shouldCheckForUpdates(cfg Config) bool {
 		return true
 	}
 
+	// Allow override for testing with short intervals
 	interval := time.Duration(cfg.Updates.CheckHours) * time.Hour
+	if testInterval := os.Getenv("TAILSTREAM_UPDATE_CHECK_INTERVAL"); testInterval != "" {
+		if duration, err := time.ParseDuration(testInterval); err == nil {
+			interval = duration
+			if os.Getenv("DEBUG") == "1" {
+				log.Printf("Using test update check interval: %v", interval)
+			}
+		}
+	}
+
 	return time.Since(info.ModTime()) > interval
 }
 
@@ -201,6 +211,10 @@ func getBinaryName() string {
 		return "tailstream-agent-linux-amd64"
 	} else if goos == "linux" && goarch == "arm64" {
 		return "tailstream-agent-linux-arm64"
+	} else if goos == "darwin" && goarch == "amd64" {
+		return "tailstream-agent-darwin-amd64"
+	} else if goos == "darwin" && goarch == "arm64" {
+		return "tailstream-agent-darwin-arm64"
 	}
 	return ""
 }


### PR DESCRIPTION
- Implement a background update checker that runs periodic checks every 5 minutes.
- Allow configuration of update check intervals via an environment variable for testing purposes.
- Add support for macOS binaries for both amd64 and arm64 architectures, improving cross-platform compatibility.