### PR TITLE
Refactor log handling to use LogEvent structs with metadata instead of raw strings

### DIFF
--- a/agent/install_test.go
+++ b/agent/install_test.go
@@ -74,23 +74,28 @@ func TestBinaryInstallation(t *testing.T) {
 	select {
 	case data := <-received:
 		// Data should be in NDJSON format (newline-delimited JSON)
-		// Now events are sent as JSON strings: "raw log line"
+		// Now events are sent as LogEvent objects: {"log":"...", "filename":"..."}
 		lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
 		if len(lines) != 1 {
 			t.Fatalf("expected 1 NDJSON line, got %d", len(lines))
 		}
 
-		var rawLog string
-		if err := json.Unmarshal(lines[0], &rawLog); err != nil {
+		var logEvent LogEvent
+		if err := json.Unmarshal(lines[0], &logEvent); err != nil {
 			t.Fatalf("bad NDJSON payload: %v", err)
 		}
 
-		// Verify the raw log line contains expected data
+		// Verify the log content contains expected data
 		expectedSubstrings := []string{"192.168.1.1", "GET", "/test", "200", "1234"}
 		for _, substr := range expectedSubstrings {
-			if !bytes.Contains([]byte(rawLog), []byte(substr)) {
-				t.Errorf("expected raw log to contain %q, got: %s", substr, rawLog)
+			if !bytes.Contains([]byte(logEvent.Log), []byte(substr)) {
+				t.Errorf("expected log content to contain %q, got: %s", substr, logEvent.Log)
 			}
+		}
+
+		// Verify filename is included
+		if logEvent.Filename == "" {
+			t.Error("expected filename to be set in LogEvent")
 		}
 
 

--- a/agent/log_parser_test.go
+++ b/agent/log_parser_test.go
@@ -57,15 +57,19 @@ func TestParseLineIntegration(t *testing.T) {
 				return
 			}
 
-			// All events should now be raw strings
-			str, ok := event.(string)
+			// All events should now be LogEvent structs with metadata
+			logEvent, ok := event.(LogEvent)
 			if !ok {
-				t.Errorf("Expected event to be a raw string, got type: %T", event)
+				t.Errorf("Expected event to be a LogEvent, got type: %T", event)
 				return
 			}
 
-			if str != tt.expected {
-				t.Errorf("Expected raw string to match original line.\nGot:  %s\nWant: %s", str, tt.expected)
+			if logEvent.Log != tt.expected {
+				t.Errorf("Expected log content to match original line.\nGot:  %s\nWant: %s", logEvent.Log, tt.expected)
+			}
+
+			if logEvent.Filename != "/test.log" {
+				t.Errorf("Expected filename to be /test.log, got: %s", logEvent.Filename)
 			}
 		})
 	}

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -43,12 +43,15 @@ func TestParseLineJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("not parsed")
 	}
-	// Events are now returned as raw strings
-	evStr, ok := ev.(string)
+	// Events are now returned as LogEvent structs with metadata
+	logEvent, ok := ev.(LogEvent)
 	if !ok {
-		t.Fatalf("Expected event to be a string, got type: %T", ev)
+		t.Fatalf("Expected event to be a LogEvent, got type: %T", ev)
 	}
-	if evStr != line {
-		t.Fatalf("Expected raw string to match original line.\nGot:  %s\nWant: %s", evStr, line)
+	if logEvent.Log != line {
+		t.Fatalf("Expected log content to match original line.\nGot:  %s\nWant: %s", logEvent.Log, line)
+	}
+	if logEvent.Filename != "/var/log/test.log" {
+		t.Fatalf("Expected filename to be /var/log/test.log, got: %s", logEvent.Filename)
 	}
 }

--- a/agent/multi_stream_test.go
+++ b/agent/multi_stream_test.go
@@ -133,15 +133,19 @@ func TestSingleStreamMultipleFormats(t *testing.T) {
 				t.Fatalf("parseLine() failed for %s", tt.name)
 			}
 
-			// All events are now raw strings - backend handles parsing
-			evStr, ok := event.(string)
+			// All events are now LogEvent structs with metadata
+			logEvent, ok := event.(LogEvent)
 			if !ok {
-				t.Errorf("Expected event to be string, got type: %T", event)
+				t.Errorf("Expected event to be LogEvent, got type: %T", event)
 				return
 			}
 
-			if evStr != tt.logLine {
-				t.Errorf("Expected raw string to match original line.\nGot:  %s\nWant: %s", evStr, tt.logLine)
+			if logEvent.Log != tt.logLine {
+				t.Errorf("Expected log content to match original line.\nGot:  %s\nWant: %s", logEvent.Log, tt.logLine)
+			}
+
+			if logEvent.Filename != "/test.log" {
+				t.Errorf("Expected filename to be /test.log, got: %s", logEvent.Filename)
 			}
 		})
 	}
@@ -198,15 +202,19 @@ func TestMultiStreamDifferentFormats(t *testing.T) {
 				return
 			}
 
-			// All events are now raw strings - backend handles parsing
-			evStr, ok := event.(string)
+			// All events are now LogEvent structs with metadata
+			logEvent, ok := event.(LogEvent)
 			if !ok {
-				t.Errorf("Expected event to be string for stream %s, got type: %T", tt.stream.Name, event)
+				t.Errorf("Expected event to be LogEvent for stream %s, got type: %T", tt.stream.Name, event)
 				return
 			}
 
-			if evStr != tt.logLine {
-				t.Errorf("Expected raw string to match original line.\nGot:  %s\nWant: %s", evStr, tt.logLine)
+			if logEvent.Log != tt.logLine {
+				t.Errorf("Expected log content to match original line.\nGot:  %s\nWant: %s", logEvent.Log, tt.logLine)
+			}
+
+			if logEvent.Filename != "/test.log" {
+				t.Errorf("Expected filename to be /test.log, got: %s", logEvent.Filename)
 			}
 		})
 	}

--- a/agent/parser.go
+++ b/agent/parser.go
@@ -1,12 +1,21 @@
 package main
 
 // Event is the normalized record to send to Tailstream.
-// Events are sent as raw strings - the backend handles all parsing.
+// Events are sent as structured JSON with metadata - the backend handles log parsing.
 type Event interface{}
 
-// parseLine returns the log line as a raw string - backend handles all parsing
+// LogEvent represents a log line with metadata about its source
+type LogEvent struct {
+	Log      string `json:"log"`
+	Filename string `json:"filename"`
+}
+
+// parseLine returns the log line with filename metadata - backend handles all parsing
 func parseLine(ll LogLine) (Event, bool) {
-	// Send the raw line as-is - backend will parse it
-	// This keeps the agent simple and lets the backend handle format detection
-	return ll.Line, true
+	// Send the raw line with filename metadata
+	// The backend will parse the log field while having context about its source
+	return LogEvent{
+		Log:      ll.Line,
+		Filename: ll.File,
+	}, true
 }


### PR DESCRIPTION
- Update tests to verify log content and filename are correctly parsed and structured. 
- This change enhances the clarity and usability of log data sent to the backend.